### PR TITLE
No auth without secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ Before doing anything you should register yourself with QuickPay and get access 
 
 ### Create a new client
 
-First you should create a client instance with `api_key` or login credentials provided by QuickPay. 
+First you should create a client instance that is anonymous or authorized with `api_key` or login credentials provided by QuickPay. 
+
+To initialise an anonymous client:
+
+```
+require 'quickpay'
+client = Quickpay::Client.new()
+```
 
 To initialise a client with QuickPay Api Key:
 

--- a/lib/quickpay/client.rb
+++ b/lib/quickpay/client.rb
@@ -3,7 +3,7 @@ module Quickpay
   class Client  
     attr_accessor :credential
     
-    def initialize credential
+    def initialize (credential = nil)
       @credential = credential
     end
     

--- a/lib/quickpay/request.rb
+++ b/lib/quickpay/request.rb
@@ -3,7 +3,7 @@ module Quickpay
   class Request
     include HTTParty
     
-    def initialize secret
+    def initialize (secret = nil)
       @secret = secret
       self.class.base_uri(BASE_URI)
     end
@@ -60,7 +60,7 @@ module Quickpay
           'User-Agent'     => user_agent,
           'Accept-Version' => "v#{Quickpay::API_VERSION}"
         }
-        heads['Authorization'] = "Basic #{authorization}" if @secret != ""
+        heads['Authorization'] = "Basic #{authorization}" if @secret != nil
         heads
       end
 

--- a/lib/quickpay/request.rb
+++ b/lib/quickpay/request.rb
@@ -56,13 +56,14 @@ module Quickpay
       end
       
       def headers
-        {
+        heads = {
           'User-Agent'     => user_agent,
-          'Authorization'  => "Basic #{authorization}",
           'Accept-Version' => "v#{Quickpay::API_VERSION}"
         }
+        heads['Authorization'] = "Basic #{authorization}" if @secret != ""
+        heads
       end
-      
+
       def user_agent
         user_agent = "quickpay-ruby-client, v#{Quickpay::VERSION}"
         user_agent += ", #{RUBY_VERSION}, #{RUBY_PLATFORM}, #{RUBY_PATCHLEVEL}"

--- a/spec/quickpay/client_spec.rb
+++ b/spec/quickpay/client_spec.rb
@@ -7,6 +7,10 @@ describe Quickpay::Client do
   it 'has credentials' do
     expect(client.credential).to eq(secret)  
   end
+
+  it 'has not credentials' do
+    expect(Quickpay::Client.new.credential).to be_nil
+  end
   
   it 'should proxy get' do
     allow_any_instance_of(Quickpay::Request).to receive(:request).with(:get, '/dummy')

--- a/spec/quickpay/request_spec.rb
+++ b/spec/quickpay/request_spec.rb
@@ -135,6 +135,10 @@ describe Quickpay::Request do
       expect(handler.send(:headers)['Authorization']).not_to be_nil
       expect(handler.send(:headers)['User-Agent']).not_to be_nil
     end
+
+    it 'should have no authorization with empty secret' do
+      expect(Quickpay::Request.new('').send(:headers)['Authorization']).to be_nil
+    end
   end
   
 end

--- a/spec/quickpay/request_spec.rb
+++ b/spec/quickpay/request_spec.rb
@@ -137,7 +137,7 @@ describe Quickpay::Request do
     end
 
     it 'should have no authorization with empty secret' do
-      expect(Quickpay::Request.new('').send(:headers)['Authorization']).to be_nil
+      expect(Quickpay::Request.new().send(:headers)['Authorization']).to be_nil
     end
   end
   


### PR DESCRIPTION
There should be no authorization header when there is no api key present. This is needed when creating new users.
