### PR TITLE
Allow head http method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Features:
 
+ - Can now HEAD
+
 (your contribution here)
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features:
 
- - Can now HEAD
+ - Can now HEAD (https://github.com/QuickPay/quickpay-ruby-client/pull/21)
 
 (your contribution here)
 

--- a/lib/quickpay/api/client.rb
+++ b/lib/quickpay/api/client.rb
@@ -26,7 +26,7 @@ module QuickPay
         end
       end
 
-      [:get, :post, :patch, :put, :delete].each do |method|
+      [:get, :post, :patch, :put, :delete, :head].each do |method|
         define_method(method) do |*args|
           Request.new(options).request(method, *args)
         end

--- a/lib/quickpay/api/request.rb
+++ b/lib/quickpay/api/request.rb
@@ -23,7 +23,7 @@ module QuickPay
           http_options[:detect_mime_type] = true
         else
           case method
-          when :get, :delete
+          when :get, :delete, :head
             http_options[:query] = data
           when :post, :patch, :put
             http_options[:body] = data.to_json

--- a/spec/quickpay/client_spec.rb
+++ b/spec/quickpay/client_spec.rb
@@ -25,6 +25,11 @@ describe QuickPay::API::Client do
     client.get("/dummy")
   end
 
+  it 'should proxy head' do
+    allow_any_instance_of(QuickPay::API::Request).to receive(:request).with(:head, '/dummy')
+    client.head("/dummy")
+  end
+
   it 'should proxy post' do
     allow_any_instance_of(QuickPay::API::Request).to receive(:request).with(:post, '/dummy', { :foo => 'bar' })
     client.post("/dummy", { foo: 'bar'})
@@ -41,4 +46,3 @@ describe QuickPay::API::Client do
   end
   
 end
-  

--- a/spec/quickpay/request_spec.rb
+++ b/spec/quickpay/request_spec.rb
@@ -38,6 +38,16 @@ describe QuickPay::API::Request do
       }
     end
 
+    context 'when method is head' do
+      it {
+        stub_request(:head, /dummy/)
+        status, body, headers = handler.request(:head, '/dummy', raw: true)
+
+        expect(status).to eq(200)
+        expect(body).to be_nil
+      }
+    end
+
     context 'headers' do
       it 'should include extra headers in request' do
         extra_headers = { 'callback-url' => 'http://test.me/thanks' }


### PR DESCRIPTION
Makes it possible to use `HEAD` http method.
