### PR TITLE
Update .travis.yml with newer Ruby Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
   - 2.1.2
+  - 2.2.7
+  - 2.3.3
+  - 2.4.1
 cache: bundler
 script: bundle exec rspec --format documentation --color
 notifications:


### PR DESCRIPTION
I suggest updating the build matrix, for testing every 2.x branch, to ensure maintainability, and show that the gem is still running, even though it hasn't been updated since 2016.