### PR TITLE
Update TravisCI with new Ruby Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 rvm:
   - 2.1.10
-  - 2.2.7
-  - 2.3.3
-  - 2.4.1
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 cache: bundler
 script: bundle exec rspec --format documentation --color
 notifications:


### PR DESCRIPTION
Updates minor versions, and adds 2.5.x to build.

Should we consider dropping 2.1-support, as it is EOL'ed last year.

Also 2.2 have gotten it's last patch (2.2.10), and is also not supported any longer. (EOL date: 2018-03-31).