### PR TITLE
Update excon dependency for CVE-2019-16779

### DIFF
--- a/quickpay-ruby-client.gemspec
+++ b/quickpay-ruby-client.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.16.1"
   spec.add_development_dependency "simplecov-console", "~> 0.4.2"
 
-  spec.add_dependency "excon", "~> 0.62.0"
+  spec.add_dependency "excon", "~> 0.71.0"
 end


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-16779

Seems like it's low severity and this gem is probably not even vulnerable if it's not using persistent connections, but I would still like to upgrade our project. Can't at this point as the quickpay gem depends on the lower version.