### PR TITLE
Fixes spec, Adds ruby 3.0 to test matrix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@
 AllCops:
   TargetRubyVersion: 2.5
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
@@ -27,7 +30,7 @@ Style/NumericLiterals:
 Style/SingleLineBlockParams:
   Enabled: false
 
-Style/MethodMissingSuper:
+Lint/MissingSuper:
   Enabled: false
 
 Style/MissingRespondToMissing:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 3.0
 cache: bundler
 script: bundle exec rake
 notifications:

--- a/lib/quickpay/api/client.rb
+++ b/lib/quickpay/api/client.rb
@@ -51,7 +51,7 @@ module QuickPay
             raise QuickPay::API::Error.by_status_code(res.status, res.body, res.headers) if res.status >= 400
 
             if res.headers["Content-Type"] == "application/json"
-              JSON.parse(res.body, options.dig(:json_opts) || @connection.data.dig(:json_opts))
+              JSON.parse(res.body, options[:json_opts] || @connection.data[:json_opts])
             else
               res.body
             end

--- a/lib/quickpay/api/error.rb
+++ b/lib/quickpay/api/error.rb
@@ -2,17 +2,29 @@ module QuickPay
   module API
     class Error < StandardError
       class BadRequest < Error; end
+
       class Unauthorized < Error; end
+
       class PaymentRequired < Error; end
+
       class Forbidden < Error; end
+
       class NotFound < Error; end
+
       class MethodNotAllowed < Error; end
+
       class NotAcceptable < Error; end
+
       class Conflict < Error; end
+
       class TooManyRequest < Error; end
+
       class InternalServerError < Error; end
+
       class BadGateway < Error; end
+
       class ServiceUnavailable < Error; end
+
       class GatewayTimeout < Error; end
 
       CLASS_MAP = {

--- a/test/client.rb
+++ b/test/client.rb
@@ -16,11 +16,9 @@ require "quickpay/api/client"
 
 Excon.defaults[:mock] = true
 
-# Excon expects two hashes
-# rubocop:disable Style/BracesAroundHashParameters
-
 describe QuickPay::API::Client do
   before do
+    # Excon expects two hashes
     Excon.stub({}, { body: "Uknown Stub", status: 500 })
   end
 
@@ -213,4 +211,3 @@ describe QuickPay::API::Client do
     e.inspect.must_equal %(#<QuickPay::API::Error::Conflict: status=409, body="Conflict", headers={"Foo"=>"bar"}>)
   end
 end
-# rubocop:enable Style/BracesAroundHashParameters


### PR DESCRIPTION
Update rubocop, fix spec, and add ruby-3.0 to testing matrix

March 31, 2019 - Ruby 2.3 support has ended
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/

Should we drop it from the testing matrix, as it currently fails? (Based on default rubocop version, not based on code, though)