### PR TITLE
simplify interface, refactor test, better documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## master
 
+### Breaking changes
+
+The interface has been changed to (https://github.com/QuickPay/quickpay-ruby-client/pull/36):
+
+- always return an array for all request types (incl. when adding the `raw: true` option)
+- order the array as `[body, status, headers]` (was `[status, body, headers]`
+- always parse JSON body unless the `raw: true` option is set
+
+The reasoning is that we almost always want the `body`, but in some case we want `status`and/or `headers` as well. Before we had to set the `raw: true` option, but then a JSON body would not be parsed.
+
+```ruby
+body, = client.get("/ping")
+body, status, = client.get("/ping")
+body, status, headers = client.get("/ping")
+body, status, headers = client.get("/ping", raw: true)
+```
+
+### New features
+
+You can now pass a block to a request:
+
+```ruby
+msg = client.get("/ping") do |body, status, headers, error|
+  case error
+  when nil
+    body["msg"]
+  when QuickPay::API::NotFound
+    nil
+  else
+    raise error
+  end
+end
+```
+
 ## v2.0.3
 
 * Add the possibility of settins options for JSON parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ body, status, headers = client.get("/ping", raw: true)
 
 ### New features
 
-You can now pass a block to a request:
+You can now pass a block to a request (https://github.com/QuickPay/quickpay-ruby-client/pull/32):
 
 ```ruby
 msg = client.get("/ping") do |body, status, headers, error|

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ client = QuickPay::API::Client.new(
     read_timeout: 60,
     write_timeout: 60,
     connect_timeout: 60,
-    json_opts: { symbolize_names: true }
+    json_opts: { symbolize_names: false }
   }
 )
 ```
@@ -71,10 +71,53 @@ client = QuickPay::API::Client.new(
 
 You can afterwards call any method described in QuickPay API with corresponding http method and endpoint. These methods are supported currently: `get`, `post`, `put`, `patch`, `delete` and `head`.
 
+Any request will return an array in the form `[body, status, headers]`:
+
 ```ruby
-client.get("/activity").each do |activity|
-  puts activity["id"]
+# Shortest form when interested in the response body only
+body, = client.get("/ping")
+puts body.inspect
+
+# Get all response information
+body, status, headers = client.get("/ping")
+puts body.inspect, status.inspect, headers.inspect
+
+```
+
+You can also do requests in block form:
+
+```ruby
+client.get("/ping") do |body, status, headers|
+  puts body.inspect
 end
+```
+It is even possible to give the block a 4th parameter to catch the error that _would_ have been raised if no block was given. This parameter is nil when the response is a success.
+
+```ruby
+client.get("/ping") do |body, status, headers, error|
+  case error
+  when nil
+    body[:id]
+  when QuickPay::API::NotFound
+    nil
+  else
+    raise error
+  end
+end
+
+```
+
+If you want raw http response body, you can add `:raw => true` parameter:
+
+```ruby
+body, status, headers = client.get("/ping", raw: true)
+
+if status == 200
+  puts JSON.parse(body).inspect
+else
+  # do something else
+end
+
 ```
 
 Beyond the endpoint, the client accepts the following options (default values shown):
@@ -85,8 +128,10 @@ Beyond the endpoint, the client accepts the following options (default values sh
   * `raw: false`
   * `json_opts: nil`
 
+Full example:
+
 ```ruby
-response = client.post(
+response, = client.post(
   "/payments/1/capture",
   body: { amount: 100 }.to_json,
   headers: { "Content-Type" => "application/json" },
@@ -94,21 +139,6 @@ response = client.post(
   raw: false,
   json_opts: { symbolize_names: true }
 )
-
-```
-
-If you want raw http response, headers Please add `:raw => true` parameter:
-
-```ruby
-status, body, headers = client.get("/activity", raw: true)
-
-if status == 200
-  JSON.parse(body).each do |activity|
-    puts activity["id"]
-  end
-else
-  # do something else
-end
 
 ```
 
@@ -143,62 +173,6 @@ end
 ```
 
 You can read more about QuickPay API responses at [https://learn.quickpay.net/tech-talk/api](https://learn.quickpay.net/tech-talk/api).
-
-### Using block form
-
-Sometimes when you want to look at status or headers `raw` isn't the best option,
-since it also prevents for example the automatic parsing of a JSON body.
-
-In this case it is possible to call `(get|post|patch|put|delete)` with a block.
-
-In this mode, the block is called with status, body and headers of the request,
-while also automatically parsing the body as JSON if the content-type header is present.
-
-The return value when used in this form is the return value of the block
-
-```ruby
-payments = client.get("/payments/") do |status, body, headers|
-  case status
-  when 403
-    []
-  when 200
-    body
-  end
-end
-```
-
-It is also possible to give the block a 4th parameter to
-catch the error that _would_ have been raised if no block was given.
-
-This parameter is nil when the response is a success
-
-```ruby
-payment = client.get("/payments/#{payment_id}") do |status, body, headers, error|
-  break nil if status == 404
-
-  if error
-    raise error
-  else
-    body
-  end
-end
-```
-
-If you don't care about all of the fields `status`, `body`, `headers` and `error`
-you can just get the specific fields you care about by using named parameters
-
-```ruby
-payments = client.get("/payments/#{payment_id}") do |body:, error:|
-  case error
-  when nil
-    body
-  when QuickPay::API::NotFound
-    nil
-  else
-    raise error
-  end
-end
-```
 
 ## Contributions
 

--- a/quickpay-ruby-client.gemspec
+++ b/quickpay-ruby-client.gemspec
@@ -20,14 +20,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "minitest", "~> 5.11.3"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 12.3.2"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "simplecov", "~> 0.16.1"
-  spec.add_development_dependency "simplecov-console", "~> 0.4.2"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov-console"
 
-  spec.add_dependency "json", "~> 2.3.0"
-
-  spec.add_dependency "excon", "~> 0.71.0"
+  spec.add_dependency "excon", "~> 0.79.0"
+  spec.add_dependency "json", "~> 2.5.0"
 end


### PR DESCRIPTION
### BREAKING CHANGE

Merging PR will require a new major version release!

The interface has been changed to:

- always return an array for all request types (incl. when adding the `raw: true` option)
- order the array as `[body, status, headers]` (was `[status, body, headers]`
- always parse JSON body unless the `raw: true` option is set

The reasoning is that we almost always want the `body`, but in some case we want `status`and/or `headers` as well. Before we had to set the `raw: true` option, but then a JSON body would not be parsed.

```ruby
body, = client.get("/ping")
body, status, = client.get("/ping")
body, status, headers = client.get("/ping")
body, status, headers = client.get("/ping", raw: true)
```