### PR TITLE
Verbose errors 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ body, status, headers = client.get("/ping", raw: true)
 
 ### New features
 
+#### Blocks
+
 You can now pass a block to a request (https://github.com/QuickPay/quickpay-ruby-client/pull/32):
 
 ```ruby
@@ -34,6 +36,23 @@ msg = client.get("/ping") do |body, status, headers, error|
     raise error
   end
 end
+```
+
+#### Verbose errors
+
+The `QuickPay::API::Error` now includes the request that yielded the error - for example:
+
+```
+#<QuickPay::API::Error::NotFound:
+  status=404,
+  body="404 Not Found",
+  headers={"Server"=>"nginx", "Date"=>"Sun, 21 Mar 2021 09:10:12 GMT", "Connection"=>"keep-alive", "X-Cascade"=>"pass", "Vary"=>"Origin"}
+  request=#<struct QuickPay::API::Client::Request
+    method=:post,
+    path="/payments",
+    body="{\"currency\":\"DKK\",\"order_id\":\"1212\"}",
+    headers={"User-Agent"=>"quickpay-ruby-client, v2.0.3", "Accept-Version"=>"v10", "Content-Type"=>"application/json"},
+    query=nil>>
 ```
 
 ## v2.0.3

--- a/README.md
+++ b/README.md
@@ -171,10 +171,25 @@ All exceptions inherits `QuickPay::API::Error`, so you can listen for any api er
 
 ```ruby
 begin
-  client.post("/payments", body: { currency: "DKK", order_id: "1212" })
+  client.post("/payments", body: { currency: "DKK", order_id: "1212" }, headers: { "Content-Type" => "application/json" })
 rescue QuickPay::API::Error => e
-  puts e.body
+  puts e.inspect
 end
+```
+
+Example error object:
+
+```
+#<QuickPay::API::Error::NotFound:
+  status=404,
+  body="404 Not Found",
+  headers={"Server"=>"nginx", "Date"=>"Sun, 21 Mar 2021 09:10:12 GMT", "Connection"=>"keep-alive", "X-Cascade"=>"pass", "Vary"=>"Origin"}
+  request=#<struct QuickPay::API::Client::Request
+    method=:post,
+    path="/payments",
+    body="{\"currency\":\"DKK\",\"order_id\":\"1212\"}",
+    headers={"User-Agent"=>"quickpay-ruby-client, v2.0.3", "Accept-Version"=>"v10", "Content-Type"=>"application/json"},
+    query=nil>>
 ```
 
 You can read more about QuickPay API responses at [https://learn.quickpay.net/tech-talk/api](https://learn.quickpay.net/tech-talk/api).

--- a/lib/quickpay/api/client.rb
+++ b/lib/quickpay/api/client.rb
@@ -44,7 +44,7 @@ module QuickPay
             path,
             scrub_body(body.dup, headers["Content-Type"]),
             headers,
-            options.fetch(:query, nil)
+            options.fetch(:query, {})
           ).freeze
 
           res = @connection.request(**req.to_h)

--- a/lib/quickpay/api/client.rb
+++ b/lib/quickpay/api/client.rb
@@ -37,15 +37,15 @@ module QuickPay
             end
           end
 
-          res = @connection.request(
+          req = {
             method: method,
             path: path,
             body: body,
             headers: headers,
             query: options.fetch(:query, {})
-          )
-
-          error = QuickPay::API::Error.by_status_code(res.status, res.body, res.headers)
+          }
+          res = @connection.request(**req)
+          error = QuickPay::API::Error.by_status_code(res.status, res.body, res.headers, req)
 
           if !options.fetch(:raw, false) && res.headers["Content-Type"] =~ %r{application/json}
             res.body = JSON.parse(res.body, options[:json_opts] || @connection.data[:json_opts])

--- a/lib/quickpay/api/client.rb
+++ b/lib/quickpay/api/client.rb
@@ -11,6 +11,8 @@ module QuickPay
         "Accept-Version" => "v10"
       }.freeze
 
+      Request = Struct.new(:method, :path, :body, :headers, :query) # rubocop:disable Lint/StructNewOverride
+
       def initialize(username: nil, password: nil, base_uri: "https://api.quickpay.net", options: {})
         opts = {
           read_timeout: options.fetch(:read_timeout, 60),
@@ -37,14 +39,15 @@ module QuickPay
             end
           end
 
-          req = {
-            method: method,
-            path: path,
-            body: body,
-            headers: headers,
-            query: options.fetch(:query, {})
-          }
-          res = @connection.request(**req)
+          req = Request.new(
+            method,
+            path,
+            scrub_body(body.dup, headers["Content-Type"]),
+            headers,
+            options.fetch(:query, nil)
+          ).freeze
+
+          res = @connection.request(**req.to_h)
           error = QuickPay::API::Error.by_status_code(res.status, res.body, res.headers, req)
 
           if !options.fetch(:raw, false) && res.headers["Content-Type"] =~ %r{application/json}
@@ -61,6 +64,18 @@ module QuickPay
 
             [res.body, res.status, res.headers]
           end
+        end
+      end
+
+      private
+
+      def scrub_body(body, content_type)
+        return "" if body.to_s.empty?
+
+        if ["application/json", "application/x-www-form-urlencoded"].include?(content_type)
+          body
+        else
+          "<scrubbed for Content-Type #{content_type}>"
         end
       end
     end

--- a/lib/quickpay/api/error.rb
+++ b/lib/quickpay/api/error.rb
@@ -43,23 +43,25 @@ module QuickPay
         504 => GatewayTimeout
       }.freeze
 
-      attr_reader :status, :body, :headers
+      attr_reader :status, :body, :headers, :request
 
-      def initialize(status, body, headers)
+      def initialize(status, body, headers, request)
         @status  = status
         @body    = body
         @headers = headers
+        @request = "#{request[:method].to_s.upcase} #{request[:path]}"
       end
 
       def to_s
-        "#<#{self.class}: status=#{status}, body=#{body.inspect}, headers=#{headers.inspect}>"
+        "#<#{self.class}: status=#{status}, body=#{body.inspect}, " \
+        "headers=#{headers.inspect} request=#{request.inspect}>"
       end
       alias_method :inspect, :to_s
 
-      def self.by_status_code(status, body, headers)
+      def self.by_status_code(status, body, headers, request)
         return if (200..399).cover? status
 
-        CLASS_MAP.fetch(status, QuickPay::API::Error).new(status, body, headers)
+        CLASS_MAP.fetch(status, QuickPay::API::Error).new(status, body, headers, request)
       end
     end
   end

--- a/lib/quickpay/api/error.rb
+++ b/lib/quickpay/api/error.rb
@@ -49,7 +49,7 @@ module QuickPay
         @status  = status
         @body    = body
         @headers = headers
-        @request = "#{request[:method].to_s.upcase} #{request[:path]}"
+        @request = request
       end
 
       def to_s

--- a/test/client.rb
+++ b/test/client.rb
@@ -247,7 +247,8 @@ describe QuickPay::API::Client do
         Excon.stub({ path: "/ping" }, { status: 409, body: "Conflict", headers: { "Foo" => "bar" } })
         client.get("/ping")
       end
-      _(e.inspect).must_equal %(#<QuickPay::API::Error::Conflict: status=409, body="Conflict", headers={"Foo"=>"bar"}>)
+      _(e.inspect).must_equal '#<QuickPay::API::Error::Conflict: status=409, body="Conflict", ' \
+                              'headers={"Foo"=>"bar"} request="GET /ping">'
     end
   end
 end

--- a/test/client.rb
+++ b/test/client.rb
@@ -247,8 +247,22 @@ describe QuickPay::API::Client do
         Excon.stub({ path: "/ping" }, { status: 409, body: "Conflict", headers: { "Foo" => "bar" } })
         client.get("/ping")
       end
-      _(e.inspect).must_equal '#<QuickPay::API::Error::Conflict: status=409, body="Conflict", ' \
-                              'headers={"Foo"=>"bar"} request="GET /ping">'
+      _(e.inspect).must_equal(
+        '#<QuickPay::API::Error::Conflict: status=409, body="Conflict", headers={"Foo"=>"bar"} ' \
+        'request=#<struct QuickPay::API::Client::Request method=:get, path="/ping", body="", ' \
+        'headers={"User-Agent"=>"quickpay-ruby-client, v2.0.3", "Accept-Version"=>"v10"}, query=nil>>'
+      )
+
+      e = assert_raises QuickPay::API::Error do
+        Excon.stub({ path: "/upload" }, { status: 409, body: "Conflict", headers: { "Foo" => "bar" } })
+        client.post("/upload", body: "binary data", headers: { "Content-Type" => "image/png" })
+      end
+      _(e.inspect).must_equal(
+        '#<QuickPay::API::Error::Conflict: status=409, body="Conflict", headers={"Foo"=>"bar"} ' \
+        'request=#<struct QuickPay::API::Client::Request method=:post, path="/upload", ' \
+        'body="<scrubbed for Content-Type image/png>", headers={"User-Agent"=>"quickpay-ruby-client, v2.0.3", '\
+        '"Accept-Version"=>"v10", "Content-Type"=>"image/png"}, query=nil>>'
+      )
     end
   end
 end


### PR DESCRIPTION
Superseeds https://github.com/QuickPay/quickpay-ruby-client/pull/26 (see PR description for motivation).

- Append a structured `request` object to the existing error object rather than changing the error object entirely.
- Only include original request body for certain content types.