### PR TITLE
Allow content type application/json variations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1
 
-* Fixed bug where variations of Content-Type application/json got scrubbed, fx application/json;charset=UTF-8 ()
+* Fixed bug where variations of Content-Type application/json got scrubbed, fx application/json;charset=UTF-8 (https://github.com/QuickPay/quickpay-ruby-client/pull/41)
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+* Fixed bug where variations of Content-Type application/json got scrubbed, fx application/json;charset=UTF-8 ()
+
 ## 3.0.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ or install from Rubygems:
 $ gem install quickpay-ruby-client
 ```
 
-It is currently tested with Ruby ( >= 2.5.x)
+It is currently tested with Ruby ( >= 2.6.x)
 
 * MRI
 * Rubinius (2.0)

--- a/lib/quickpay/api/client.rb
+++ b/lib/quickpay/api/client.rb
@@ -72,7 +72,7 @@ module QuickPay
       def scrub_body(body, content_type)
         return "" if body.to_s.empty?
 
-        if ["application/json", "application/x-www-form-urlencoded"].include?(content_type)
+        if [%r{application/.*json.*}, %r{application/x-www-form-urlencoded}].any? { |regex| regex.match(content_type) }
           body
         else
           "<scrubbed for Content-Type #{content_type}>"

--- a/lib/quickpay/api/version.rb
+++ b/lib/quickpay/api/version.rb
@@ -1,5 +1,5 @@
 module QuickPay
   module API
-    VERSION = "3.0.0".freeze
+    VERSION = "3.0.1".freeze
   end
 end

--- a/quickpay-ruby-client.gemspec
+++ b/quickpay-ruby-client.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "quickpay/api/version"
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = ">= 2.6.0" # rubocop:disable Gemspec/RequiredRubyVersion
+  spec.required_ruby_version = ">= 2.5.0" # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.name          = "quickpay-ruby-client"
   spec.version       = QuickPay::API::VERSION

--- a/quickpay-ruby-client.gemspec
+++ b/quickpay-ruby-client.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "quickpay/api/version"
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = ">= 2.5.0" # rubocop:disable Gemspec/RequiredRubyVersion
+  spec.required_ruby_version = ">= 2.6.0" # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.name          = "quickpay-ruby-client"
   spec.version       = QuickPay::API::VERSION

--- a/test/client.rb
+++ b/test/client.rb
@@ -116,6 +116,28 @@ describe QuickPay::API::Client do
         _(response).must_equal({ :foo => "bar" })
       end
     end
+
+    it "returns a ruby Hash if content type is weird application/json" do
+      Excon.stub(
+        { path: "/ping" },
+        lambda do |request_params|
+          {
+            body: request_params[:body],
+            headers: { "Content-Type" => "application/stuff+json" },
+            status: 200
+          }
+        end
+      )
+
+      # client returns Ruby Hash with string keys
+      subject.post(
+        "/ping",
+        body: { "foo" => "bob" },
+        headers: { "Content-Type" => "application/stuff+json" }
+      ).tap do |response,|
+        _(response).must_equal({ "foo" => "bob" })
+      end
+    end
   end
 
   describe "request with block" do


### PR DESCRIPTION
our ruby client should allow variations of application/json, this is required for things like invoicing https://github.com/QuickPay/manager-server/blob/373ecc8cc1aa2492276776b26046ba5035ee0507/lib/manager-server/invoicing/client.rb#L23