### PR TITLE
relax version spec for excon gem

### DIFF
--- a/quickpay-ruby-client.gemspec
+++ b/quickpay-ruby-client.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-console"
 
-  spec.add_dependency "excon", "~> 0.79.0"
+  spec.add_dependency "excon", "~> 0.79"
   spec.add_dependency "json", "~> 2.5.0"
 end


### PR DESCRIPTION
as the current spec effectively locks exon gem to version 2years old

I've run `bundle exec rake test:specs` and it's GREEN