### PR TITLE
dont use specific versions of gems

### DIFF
--- a/lib/quickpay/api/version.rb
+++ b/lib/quickpay/api/version.rb
@@ -1,5 +1,5 @@
 module QuickPay
   module API
-    VERSION = "3.0.1".freeze
+    VERSION = "3.0.2".freeze
   end
 end

--- a/quickpay-ruby-client.gemspec
+++ b/quickpay-ruby-client.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-console"
 
-  spec.add_dependency "excon", "~> 0.79.0"
-  spec.add_dependency "json", "~> 2.5.0"
+  spec.add_dependency "excon", ">= 0.79"
+  spec.add_dependency "json", "~> 2", ">= 2.5"
 end


### PR DESCRIPTION
fixes the problem brought up in #45 but allows for upgrading
the excon gem to any version greater than 0.79 and the json gem to any 2.x version greater than or equal to 2.5
