### PR TITLE
Lock the JSON version until the root cause is found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.3
+
+Limit json dependency to < 2.11 to avoid potential breaking changes in json gem 2.11.0
+
 ## 4.0.2
 
 Make overwritten Authorization header possible again.

--- a/lib/quickpay/api/version.rb
+++ b/lib/quickpay/api/version.rb
@@ -1,5 +1,5 @@
 module QuickPay
   module API
-    VERSION = "4.0.2".freeze
+    VERSION = "4.0.3".freeze
   end
 end

--- a/quickpay-ruby-client.gemspec
+++ b/quickpay-ruby-client.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "json", "~> 2", ">= 2.5"
+  # Allow 2.0 through 2.10.X to avoid breaking changes in 2.11.0
+  spec.add_dependency "json", "~> 2.0", "< 2.11"
 end


### PR DESCRIPTION
I have tested with 2.11...2.13, and all of them fail with the following error. Let's lock the version until we create a ticket and find the reason.

```bash
  test_0001_authorizes the transaction if accquire has authorizedERROR (0.00s)
Minitest::UnexpectedError:         NoMethodError: undefined method `call' for an instance of Hash
            /usr/local/bundle/gems/json-2.11.3/lib/json/common.rb:36:in `block in object_class_proc'
            /usr/local/bundle/gems/json-2.11.3/lib/json/common.rb:47:in `block in array_class_proc'
            /usr/local/bundle/gems/json-2.11.3/lib/json/common.rb:336:in `parse'
            /usr/local/bundle/gems/json-2.11.3/lib/json/common.rb:336:in `parse'
            /usr/local/bundle/gems/quickpay-ruby-client-3.0.2/lib/quickpay/api/client.rb:56:in `block (2 levels) in <class:Client>'
```